### PR TITLE
Feature/read

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dac5578"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2018"
 
 authors = ["Christian Maniewski <code@chmanie.com>"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # dac5578 &emsp;
 
-*Texas Instruments DAC5578 Driver for Rust Embedded HAL*
+*Texas Instruments DACx578 Driver for Rust Embedded HAL*
 This is a driver crate for embedded Rust. It's built on top of the Rust
 [embedded HAL](https://github.com/rust-embedded/embedded-hal)
-It supports sending commands to a TI DAC5578 over I2C.
+It supports sending commands to a TI DAC5578/DAC6578/DAC7578 over I2C.
 
 The driver can be initialized by calling create and passing it an I2C interface.
 The device address (set by ADDR0) also needs to be specified.
@@ -22,7 +22,7 @@ To set the dac output for channel A:
 # use dac5578::*;
 # let mut i2c = Mock::new(&[Transaction::write(98, vec![0x40, 0xff, 0xf0]),]);
 # let mut dac = DAC5578::new(i2c, Address::PinLow);
-dac.write_channel(Channel::A, 128);
+dac.write_channel(Channel::A, 0x8000);
 ```
 
 ## More information

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,25 +137,25 @@ where
     }
 
     /// Write to the channel's DAC input register
-    pub fn write(&mut self, channel: Channel, data: u8) -> Result<(), E> {
+    pub fn write(&mut self, channel: Channel, data: u16) -> Result<(), E> {
         let bytes = Self::encode_command(CommandType::WriteToChannel, channel as u8, data);
         self.i2c.write(self.address, &bytes)
     }
 
     /// Selects DAC channel to be updated
-    pub fn update(&mut self, channel: Channel, data: u8) -> Result<(), E> {
+    pub fn update(&mut self, channel: Channel, data: u16) -> Result<(), E> {
         let bytes = Self::encode_command(CommandType::UpdateChannel, channel as u8, data);
         self.i2c.write(self.address, &bytes)
     }
 
     /// Write to DAC input register for a channel and update channel DAC register
-    pub fn write_and_update(&mut self, channel: Channel, data: u8) -> Result<(), E> {
+    pub fn write_and_update(&mut self, channel: Channel, data: u16) -> Result<(), E> {
         let bytes = Self::encode_command(CommandType::WriteToChannelAndUpdate, channel as u8, data);
         self.i2c.write(self.address, &bytes)
     }
 
     /// Write to Selected DAC Input Register and Update All DAC Registers (Global Software LDAC)
-    pub fn write_and_update_all(&mut self, channel: Channel, data: u8) -> Result<(), E> {
+    pub fn write_and_update_all(&mut self, channel: Channel, data: u16) -> Result<(), E> {
         let bytes =
             Self::encode_command(CommandType::WriteToChannelAndUpdateAll, channel as u8, data);
         self.i2c.write(self.address, &bytes)
@@ -187,7 +187,8 @@ where
     }
 
     /// Encode command type, channel and data into a three byte command
-    fn encode_command(command: CommandType, access: u8, msdb: u8) -> [u8; 3] {
-        [command as u8 | access, msdb, 0]
+    fn encode_command(command: CommandType, access: u8, value: u16) -> [u8; 3] {
+        let value_bytes = value.to_be_bytes();
+        [command as u8 | access, value_bytes[0], value_bytes[1]]
     }
 }


### PR DESCRIPTION
I added support for the other chips in the family (by changing u8 for u16).  Note that this change is not backwards compatible.  I also added a `read` function to read the current value of a channel.  Contrary to the commit message, I subsequently tested it, and it seemed to work fine.